### PR TITLE
README.md: update comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ The work seems to be based on [**rstpd**](https://github.com/shemminger/RSTP).
 This repo tries to converge the original works of rstpd/mstpd and the works of
 others (e.g. Cumulus Linux).
 
-There are 3 main branches:
+There are 2 main branches:
 - **upstream** - which is a git-svn clone from SourceForge
 - **master** - generic updates (on top of uptream)
-- **openwrt** - specific changes for OpenWRT
 


### PR DESCRIPTION
For now the openwrt branch will not be exposed, until we can properly
define a switch backend for mstpd.
So far, we've not been able to do so and we keep changing stuff too rapidly.

Signed-off-by: Alexandru Ardelean <aa@ocedo.com>