### PR TITLE
libnetlink.c: increase netlink socket buffers to 256k default

### DIFF
--- a/libnetlink.c
+++ b/libnetlink.c
@@ -26,6 +26,17 @@
 #include "log.h"
 #include "libnetlink.h"
 
+#ifndef DEFAULT_RTNL_BUFSIZE
+#define DEFAULT_RTNL_BUFSIZE	256 * 1024
+#endif
+
+#ifndef RTNL_SND_BUFSIZE
+#define RTNL_SND_BUFSIZE	DEFAULT_RTNL_BUFSIZE
+#endif
+#ifndef RTNL_RCV_BUFSIZE
+#define RTNL_RCV_BUFSIZE	DEFAULT_RTNL_BUFSIZE
+#endif
+
 void rtnl_close(struct rtnl_handle *rth)
 {
 	close(rth->fd);
@@ -35,8 +46,8 @@ int rtnl_open_byproto(struct rtnl_handle *rth, unsigned subscriptions,
 		      int protocol)
 {
 	socklen_t addr_len;
-	int sndbuf = 32768;
-	int rcvbuf = 32768;
+	int sndbuf = RTNL_SND_BUFSIZE;
+	int rcvbuf = RTNL_RCV_BUFSIZE;
 
 	memset(rth, 0, sizeof(*rth));
 


### PR DESCRIPTION
Patch inspired from:
   http://oss.cumulusnetworks.com/CumulusLinux-2.5.1/patches/mstpd/mstpd-exit-issue.patch

Seems 32k is not enough for netlink messages when dealing
with 24+ ports.
This will also allow to override the default buf sizes via CFLAGS.