### PR TITLE
Build with CFLAGS and CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ endif
 all: mstpd mstpctl
 
 mstpd: $(DOBJECTS)
-	$(CC) -o $@ $(DOBJECTS) $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(DOBJECTS) $(LDFLAGS)
 
 mstpctl: $(CTLOBJECTS)
-	$(CC) -o $@ $(CTLOBJECTS) $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(CTLOBJECTS) $(LDFLAGS)
 
 -include .depend
 


### PR DESCRIPTION
Many packaging tools, like the Debian toolchain, pass down options through CFLAGS and CPPFLAGS, IE: hardening options. Include them explicitly in the Makefile.