### PR TITLE
bridge_track: do not process packets that do not meet BPDU validation

### DIFF
--- a/bridge_track.c
+++ b/bridge_track.c
@@ -389,17 +389,16 @@ void bridge_bpdu_rcv(int if_index, const unsigned char *data, int len)
      */
     struct llc_header *h;
     unsigned int l;
-    TST(len > sizeof(struct llc_header),);
+    if (!(len > sizeof(struct llc_header)))
+        return;
     h = (struct llc_header *)data;
-    TST(0 == memcmp(h->dest_addr, bridge_group_address, ETH_ALEN),
-             INFO("ifindex %d, len %d, %02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
-                  if_index, len,
-                  h->dest_addr[0], h->dest_addr[1], h->dest_addr[2],
-                  h->dest_addr[3], h->dest_addr[4], h->dest_addr[5])
-       );
+    if (memcmp(h->dest_addr, bridge_group_address, ETH_ALEN))
+        return;
     l = __be16_to_cpu(h->len8023);
-    TST(l <= ETH_DATA_LEN && l <= len - ETH_HLEN && l >= LLC_PDU_LEN_U, );
-    TST(h->d_sap == LLC_SAP_BSPAN && h->s_sap == LLC_SAP_BSPAN && (h->llc_ctrl & 0x3) == LLC_PDU_TYPE_U,);
+    if (!((l <= ETH_DATA_LEN && l <= len - ETH_HLEN && l >= LLC_PDU_LEN_U)))
+        return;
+    if (!(h->d_sap == LLC_SAP_BSPAN && h->s_sap == LLC_SAP_BSPAN && (h->llc_ctrl & 0x3) == LLC_PDU_TYPE_U))
+        return
 
     MSTP_IN_rx_bpdu(prt,
                     /* Don't include LLC header */


### PR DESCRIPTION
We seem to be getting packets with MAC 01:80:c2:00:00:XX, where XX is
one of the other MACs in this list:
 http://www.ieee802.org/1/files/public/docs2007/admin-jeffree-standard-group-mac-address-assignments-0307.pdf

It could be that the bpf filter did not install properly
in the packet.c module.

Maybe this could confuse the internal state machine of mstpd.
However, what we're seeing is mostly log spam.

In any case, mstpd's state machine should not run for packets
other than the ones addressed to 01:80:c2:00:00:00.

So, the proper fix looks like turning on all checks in bridge_bpdu_rcv()
to exit the call if some validation did not meet BPDU requirements.

Signed-off-by: Alexandru Ardelean <aardelean@riverbed.com>