### PR TITLE
Read $MSTP_BRIDGES from /etc/*.conf

### DIFF
--- a/bridge-stp
+++ b/bridge-stp
@@ -33,7 +33,9 @@ checkpid()
         local line p
         read line < "$pid_file"
         for p in $line; do
-            [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] && pid="$pid $p"
+            if [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ]; then
+                pid="$pid $p"
+            fi
         done
         if [ -n "$pid" ]; then
             return 0

--- a/bridge-stp
+++ b/bridge-stp
@@ -15,11 +15,12 @@ fi
 bridge=$1
 service=mstpd
 pid_file=/var/run/${service}.pid
+conf_file=/etc/bridge-stp.conf
 bin_dir=/sbin
 net_dir=/sys/class/net
 
 # Set this to the list of bridges for which MSTP should be used.
-# Comment this out to allow any valid bridge to use used.
+# Set to empty value to allow any valid bridge to use MSTP.
 MSTP_BRIDGES="br0"
 
 # Set $pid to pids from /var/run* for {program}.  $pid should be declared
@@ -43,7 +44,10 @@ checkpid()
 }
 
 case $2 in
-    start) 
+    start)
+        if [ -e "$conf_file" ]; then
+            . "$conf_file" || exit
+        fi
         checkpid $pid_file || exit 1
         if [ -d "$net_dir/$bridge/bridge" ]; then
             allowed=1

--- a/bridge-stp
+++ b/bridge-stp
@@ -32,8 +32,8 @@ checkpid()
     if [ -f "$1" ] ; then
         local line p
         read line < "$pid_file"
-        for p in $line ; do
-            [ -z "${p//[0-9]/}" -a -d "/proc/$p" ] && pid="$pid $p"
+        for p in $line; do
+            [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] && pid="$pid $p"
         done
         if [ -n "$pid" ]; then
             return 0

--- a/bridge-stp
+++ b/bridge-stp
@@ -9,7 +9,7 @@ PATH="/sbin:/usr/sbin:/bin:/usr/bin"
 export PATH
 
 if [ $# -ne 2 ]; then
-    echo "Usage: bridge-stp <bridge> {start|stop}"
+    echo "Usage: bridge-stp <bridge> {start|stop}" >&2
     exit 1
 fi
 bridge=$1
@@ -68,7 +68,7 @@ case $2 in
         exec $bin_dir/mstpctl delbridge $bridge
         ;;
     *)
-        echo "Unknown action:" $2
-        echo "Usage: bridge-stp <bridge> {start|stop}"
+        echo "Unknown action: $2" >&2
+        echo "Usage: bridge-stp <bridge> {start|stop}" >&2
         exit 1
 esac

--- a/bridge-stp
+++ b/bridge-stp
@@ -51,7 +51,7 @@ case $2 in
         checkpid $pid_file || exit 1
         if [ -d "$net_dir/$bridge/bridge" ]; then
             allowed=1
-            if [[ -n "$MSTP_BRIDGES" ]]; then
+            if [ -n "$MSTP_BRIDGES" ]; then
                 allowed=0
                 for b in $MSTP_BRIDGES; do
                     if [ "$bridge" == "$b" ]; then
@@ -59,7 +59,7 @@ case $2 in
                     fi
                 done
             fi
-            if [[ "$allowed" -eq 1 ]]; then
+            if [ "$allowed" -eq 1 ]; then
                 exec $bin_dir/mstpctl addbridge $bridge
             fi
         fi


### PR DESCRIPTION
Editing a script in /bin doesn't feel particularly nice, so this adds `/etc/bridge-stp.conf` for the configuration.